### PR TITLE
Add resource compiler for Vision

### DIFF
--- a/framework/View/Compilers/Traits/CompileResources.php
+++ b/framework/View/Compilers/Traits/CompileResources.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Framework\View\Compilers\Traits;
+
+use Exception;
+
+/**
+ * Trait CompileResources
+ *
+ * This trait provides methods for compiling resources in views.
+ *
+ * @package Framework\View\Compilers\Traits
+ */
+trait CompileResources
+{
+    /**
+     * Compile resources in the given content.
+     *
+     * @param string $content The content to be compiled.
+     * @return string The compiled content.
+     */
+    protected function CompileResources($content)
+    {
+        $patterns = [
+            '/@resource\s?\(\s*(.+?)\s*\);?/' => '%s',
+        ];
+
+        foreach ($patterns as $pattern => $replacement) {
+            $callback = function ($matches) use ($replacement) {
+                $whitespace = empty($matches[3]) ? '' : $matches[3] . $matches[3];
+                $file = $matches[1];
+
+                try {
+                    $wrapped = $this->minify($this->fs->get(resource_path()."/".$file));
+                } catch(Exception $e) {
+                    $wrapped = "/* ".$e->getMessage()." */";
+                }
+                return sprintf($replacement, $wrapped) . $whitespace;
+            };
+
+            $content = preg_replace_callback($pattern, $callback, $content);
+        }
+
+        return $content;
+    }
+
+    /**
+     * Minify the given content by removing comments and whitespaces resulting in a minified version.
+     *
+     * @param string $content The original content to minify.
+     * @return string The minified content.
+     */
+    private function minify($content)
+    {
+        $content = preg_replace('!/\*[^*]*\*+([^/][^*]*\*+)*/!', '', $content);
+        $content = preg_replace('/\s*([{}|:;,])\s+/', '$1', $content);
+        $content = str_replace(array("\r\n", "\r", "\n", "\t", '  ', '    ', '    '), '',$content);
+
+        return $content;
+    }
+}

--- a/framework/View/Compilers/VisionCompiler.php
+++ b/framework/View/Compilers/VisionCompiler.php
@@ -12,7 +12,8 @@ namespace Framework\View\Compilers;
  */
 class VisionCompiler extends Compiler
 {
-    use Traits\CompileEchos,
+    use Traits\CompileResources,
+        Traits\CompileEchos,
         Traits\CompileIfs,
         Traits\CompileForeachs;
 
@@ -86,6 +87,7 @@ class VisionCompiler extends Compiler
      */
     public function compileContent($content)
     {
+        $content = $this->compileResources($content);
         $content = $this->compileRegularEchos($content);
         $content = $this->compileIfs($content);
         $content = $this->compileForeachs($content);


### PR DESCRIPTION
In this commit, we introduce a resource compiler for the template engine. This update enables the direct injection of minified resources into views, providing developers with a streamlined approach to define and incorporate resources into their templates.

Changes Made:

- Resource Compiler: Implemented a resource compiler to facilitate the minification and direct injection of resources into template views.
- Streamlined Integration: Developers can now easily define and include resources directly within views, enhancing the efficiency of resource management.
- Improved Minification: The resource compiler ensures that included resources are minified, optimizing the overall performance of the application.

Branch: enhancement/view-resource-compiling